### PR TITLE
Fixed wrong income in coverage

### DIFF
--- a/resources/shops.json
+++ b/resources/shops.json
@@ -73,7 +73,7 @@
         "description": "Generiert 125 Commits pro Klick",
         "initialCost": 20000,
         "costFactor": 1.8,
-        "income": 25
+        "income": 125
       },
       {
         "key": "suit",


### PR DESCRIPTION
code coverage should give 125 commits but is currently just 25